### PR TITLE
remove superflous argument

### DIFF
--- a/libkiara/backend.py
+++ b/libkiara/backend.py
@@ -69,7 +69,7 @@ def makedirs(path):
 	while parts:
 		path = os.path.join(path, parts.pop(0))
 		if not os.path.exists(path):
-			os.makedirs(path, exist_ok=True)
+			os.makedirs(path)
 
 def rmdirp(path):
 	while path:


### PR DESCRIPTION
exist_ok doesn't matter here, since you're already testing for !os.path.exists(path).
